### PR TITLE
WP-1919: AKTA Migration: Update WordPress plugin

### DIFF
--- a/exports/class-amp-anvplayer-embed.php
+++ b/exports/class-amp-anvplayer-embed.php
@@ -28,7 +28,7 @@ class ANVATO_AMP_Anvplayer_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		$parameters = anvato_shortcode_get_parameters__for_exports( $attr );
 
-		$iframe_src = 'https://w3.cdn.anvato.net/player/prod/v3/anvload.html?key=' . base64_encode( json_encode( $parameters['json'] ) );
+		$iframe_src = 'https://w3.mp.lura.live/player/prod/v3/anvload.html?key=' . base64_encode( json_encode( $parameters['json'] ) );
 
 		$iframe_width = 640;
 		if ( !empty( $parameters['player']['width'] ) && 'px' === $parameters['player']['width_type'] ) {

--- a/exports/fia-anvplayer-embed.php
+++ b/exports/fia-anvplayer-embed.php
@@ -8,7 +8,7 @@ add_shortcode( 'anvplayer', function( $attr ) {
 
 	$parameters = anvato_shortcode_get_parameters__for_exports( $attr );
 	
-	$iframe_src = 'https://w3.cdn.anvato.net/player/prod/v3/anvloadfbia.html?anvkey=' . base64_encode( json_encode( $parameters['json'] ) );
+	$iframe_src = 'https://w3.mp.lura.live/player/prod/v3/anvloadfbia.html?anvkey=' . base64_encode( json_encode( $parameters['json'] ) );
 
 	$iframe_width = 640;
 	if ( !empty( $parameters['player']['width'] ) && 'px' === $parameters['player']['width_type'] ) {

--- a/mexp/js.js
+++ b/mexp/js.js
@@ -214,7 +214,7 @@ media.view.MEXP.prototype.fetchedSuccess = function( response )
 function anv_preview(mcp_id, video_id, type, accesskey)
 {
 	var ptype = type === 'video' || type === 'live' ? 'video' : 'playlist';
-	var player_js_url = "https://w3.cdn.anvato.net/player/prod/v3/scripts/anvload.js";
+	var player_js_url = "https://w3.mp.lura.live/player/prod/v3/scripts/anvload.js";
 	var script = jQuery("<script src='"+player_js_url+"'></script>");
 	if(accesskey)
 	{


### PR DESCRIPTION
## Summary

Update the Anvato WordPress plugin with the new Akta WordPress plugin so that the connection between Anvato MCP and WP continues to function

Acceptance Criteria
Producer should be able to perform all functions of finding and embedding videos as is currently available on production sites. Tasks include:

Connect any WordPress site to a specific station’s MCP instance(s) using the WordPress Anvato configuration

Producer should be able to search the content library for videos in MCP from within WordPress

Producer should be able to embed video (VOD or livestream) in common areas including lead media, post/page body

User should see videos embedded by producer on a live site

## Notes for reviewers

None.

## Changelog entries

[View the project changelog](https://github.com/alleyinteractive/lakana/blob/production/private/CHANGELOG.md).

- **Changed**: Update Anvato player urls to use the new lura live urls for the Akta Player

## Ticket(s)

- https://nexstarpsg.atlassian.net/browse/WP-1919
